### PR TITLE
ApiClient, Repository and ViewModel Setup

### DIFF
--- a/lib/core/data/api_client.dart
+++ b/lib/core/data/api_client.dart
@@ -1,0 +1,15 @@
+import 'package:dio/dio.dart';
+
+class ApiClient {
+  ApiClient({required this.baseUrl});
+
+  final String baseUrl;
+
+  Dio get dio => Dio(
+        BaseOptions(
+          baseUrl: baseUrl,
+          connectTimeout: const Duration(seconds: 60),
+          receiveTimeout: const Duration(seconds: 60),
+        ),
+      );
+}

--- a/lib/core/dependencies/registry.dart
+++ b/lib/core/dependencies/registry.dart
@@ -1,0 +1,12 @@
+import 'package:get_it/get_it.dart';
+import 'package:shopping_app/core/data/api_client.dart';
+import 'package:shopping_app/features/home/data/home_repository.dart';
+
+void registerDependencies({String baseUrl = ''}) {
+  final apiClient = ApiClient(baseUrl: baseUrl);
+  GetIt.I.registerLazySingleton<ApiClient>(() => apiClient);
+
+  GetIt.I.registerLazySingleton<HomeRepository>(
+    () => HomeRepository(client: apiClient),
+  );
+}

--- a/lib/core/presentation/base_view_model.dart
+++ b/lib/core/presentation/base_view_model.dart
@@ -1,0 +1,12 @@
+import 'package:flutter/foundation.dart';
+
+class BaseViewModel {
+  final ValueNotifier<bool> _loading = ValueNotifier(false);
+  ValueNotifier<bool> get loading => _loading;
+
+  bool get isLoading => _loading.value;
+
+  void setLoading(bool val) {
+    _loading.value = val;
+  }
+}

--- a/lib/core/utils/logger.dart
+++ b/lib/core/utils/logger.dart
@@ -1,0 +1,25 @@
+import 'dart:developer' as dev;
+
+AppLogger getLogger(Object scope) => _Logger(scope.toString());
+bool _showLogs = false;
+
+abstract class AppLogger {
+  AppLogger._();
+
+  static void configure({required bool showLogs}) {
+    _showLogs = showLogs;
+  }
+
+  void log(Object? e) {}
+}
+
+class _Logger implements AppLogger {
+  _Logger(this.scope);
+
+  final String scope;
+
+  @override
+  void log(Object? e) {
+    if (_showLogs) dev.log("$e");
+  }
+}

--- a/lib/features/home/data/home_repository.dart
+++ b/lib/features/home/data/home_repository.dart
@@ -1,0 +1,21 @@
+import 'package:get_it/get_it.dart';
+import 'package:shopping_app/core/data/api_client.dart';
+import 'package:shopping_app/core/models/product_model.dart';
+
+class HomeRepository {
+  HomeRepository({ApiClient? client})
+      : _client = client ?? GetIt.I<ApiClient>();
+
+  final ApiClient _client;
+
+  Future<List<Product>> getProducts() async {
+    final response = await _client.dio.get('products');
+    if (response.statusCode == 200) {
+      // success, parse response body
+    } else {
+      // request failed, you may want to throw a custom error
+    }
+
+    return [];
+  }
+}

--- a/lib/features/home/presentation/view_model/home_view_model.dart
+++ b/lib/features/home/presentation/view_model/home_view_model.dart
@@ -1,0 +1,26 @@
+import 'package:flutter/foundation.dart';
+import 'package:get_it/get_it.dart';
+import 'package:shopping_app/core/models/product_model.dart';
+import 'package:shopping_app/core/presentation/base_view_model.dart';
+import 'package:shopping_app/core/utils/logger.dart';
+import 'package:shopping_app/features/home/data/home_repository.dart';
+
+class HomeViewModel extends BaseViewModel {
+  late final _logger = getLogger(HomeViewModel);
+
+  final ValueNotifier<List<Product>> _productsNotifier = ValueNotifier([]);
+  ValueNotifier<List<Product>> get productsNotifier => _productsNotifier;
+
+  Future<void> getProducts() async {
+    try {
+      setLoading(true);
+      final products = await GetIt.I<HomeRepository>().getProducts();
+      _productsNotifier.value = products;
+    } catch (e) {
+      // an error was thrown.
+      // this needs to be handled and shown in the UI.
+      _logger.log(e);
+    }
+    setLoading(false);
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,7 +1,14 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:shopping_app/core/dependencies/registry.dart';
+import 'package:shopping_app/core/utils/logger.dart';
 import 'package:shopping_app/views/index_page.dart';
 
 void main() {
+  AppLogger.configure(showLogs: kDebugMode);
+  // String.fromEnvironment reads environment variables that you pass to the
+  // flutter run command using --dart-define OR --dart-define-from-file
+  registerDependencies(baseUrl: const String.fromEnvironment('BASE_URL'));
   runApp(const MyApp());
 }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -31,11 +31,8 @@ dependencies:
   google_fonts: ^6.1.0
   flutter:
     sdk: flutter
-
-
-  # The following adds the Cupertino Icons font to your application.
-  # Use with the CupertinoIcons class for iOS style icons.
-  cupertino_icons: ^1.0.2
+  dio: ^5.4.1
+  get_it: ^7.6.7
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
### Major Changes

- Adds `ApiClient` which configures and exposes `Dio` for network requests
- Adds `BaseViewModel` which other view models will extend from
- Adds example repository (`HomeRepository`) showing how repositories will use the `ApiClient`
- Adds dependency registry for registering dependencies using `Get It`
- Adds example api call from view model in `HomeViewModel`
- Adds logger